### PR TITLE
Add libsipe support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN apk add --no-cache --update libpurple \
 	glib-dev \
 	protobuf-c-dev \
 	mercurial \
+	libxml2-dev \
     && cd /tmp \
     && git clone https://github.com/bitlbee/bitlbee.git \
     && cd bitlbee \
@@ -77,6 +78,14 @@ RUN apk add --no-cache --update libpurple \
     && make \
     && make install \
     && strip /usr/lib/purple-2/libslack.so \
+    && cd /tmp \
+    && git clone https://github.com/tieto/sipe.git \
+    && cd sipe \
+    && ./autogen.sh \
+    && ./configure --build=x86_64-alpine-linux-musl --host=x86_64-alpine-linux-musl --prefix=/usr \
+    && make \
+    && make install \
+    && strip /usr/lib/purple-2/libsipe.so \
     && rm -rf /tmp/* \
     && rm -rf /usr/include/bitlbee \
     && rm -f /usr/lib/pkgconfig/bitlbee.pc \


### PR DESCRIPTION
Adds support for following messaging services:

    * Skype for Business
    * Microsoft Office 365
    * Microsoft Business Productivity Online Suite (BPOS)
    * Microsoft Lync Server
    * Microsoft Office Communications Server (OCS 2007/2007 R2)
    * Microsoft Live Communications Server (LCS 2003/2005)

(Source: https://github.com/tieto/sipe)
