### PR TITLE
Added bash to packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN addgroup -g 101 -S bitlbee \
 	glib \
 	protobuf-c \
 	discount-libs \
+	bash \
  && apk add --no-cache --update --virtual .build-dependencies \
 	git \
 	make \


### PR DESCRIPTION
I added bash to the container for easier debugging. In that way you have a more easy way to interact inside the container.