### PR TITLE
use updated libpurple-signal commit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -293,7 +293,7 @@ RUN echo MATRIX=${MATRIX} > /tmp/status \
 FROM bitlbee-build as signald-build
 
 ARG SIGNAL=1
-ARG SIGNAL_VERSION=af18341
+ARG SIGNAL_VERSION=f53a118
 
 RUN echo SIGNAL=${SIGNAL} > /tmp/status \
  && if [ ${SIGNAL} -eq 1 ]; \


### PR DESCRIPTION
The current Dockerfile uses an old commit the of libpurple-signald plugin that doesn't work with the existing version of signald. It results in a crash.

You can see the following issues for more details on what I was experiencing: 
https://github.com/hoehermann/libpurple-signald/issues/40
https://gitlab.com/signald/signald/-/issues/126


However, updating libpurple-signald to the current commit fixed all my issues. 